### PR TITLE
Eclipse success vs Maven fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,14 @@
 	</developers>
 	<dependencies>
 		<dependency>
+			<groupId>org.openqa.selenium.client-drivers
+			</groupId>
+			<artifactId>selenium-java-client-driver
+			</artifactId>
+			<version>0.9.2</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.4</version>

--- a/src/main/java/br/com/caelum/seleniumdsl/htmlunit/HtmlFormWrapper.java
+++ b/src/main/java/br/com/caelum/seleniumdsl/htmlunit/HtmlFormWrapper.java
@@ -22,7 +22,7 @@ class HtmlFormWrapper {
 		this.delegate = delegate;
 	}
 
-	public <X> X getFirstByXPath(String xpathExpr) {
+	public <T> T getFirstByXPath(String xpathExpr) {
 		return delegate.getFirstByXPath(xpathExpr);
 	}
 

--- a/src/main/java/br/com/caelum/seleniumdsl/htmlunit/HtmlFormWrapper.java
+++ b/src/main/java/br/com/caelum/seleniumdsl/htmlunit/HtmlFormWrapper.java
@@ -22,13 +22,15 @@ class HtmlFormWrapper {
 		this.delegate = delegate;
 	}
 
-	public <T> T getFirstByXPath(String xpathExpr) {
-		return delegate.getFirstByXPath(xpathExpr);
+	@SuppressWarnings("unchecked")
+	public <X> X getFirstByXPath(String xpathExpr) {
+		return (X)delegate.getFirstByXPath(xpathExpr);
 	}
 
+	@SuppressWarnings("unchecked")
 	public <I extends HtmlInput> I getInputByNameOrId(String name) {
 		try {
-			return getInputByNameOrIdOrDie(name);
+			return (I)getInputByNameOrIdOrDie(name);
 		} catch (Exception e) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Input with name or id " + name + " not found");
@@ -54,16 +56,18 @@ class HtmlFormWrapper {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	public <I extends HtmlInput> I getInputByNameOrIdOrDie(String name) throws ElementNotFoundException {
 		try {
-			return delegate.getInputByName(name);
+			return (I)delegate.getInputByName(name);
 		} catch (ElementNotFoundException e) {
-			return delegate.getElementById(name);
+			return (I)delegate.getElementById(name);
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	public <E extends HtmlElement> E getElementByIdOrDie(String id) throws ElementNotFoundException {
-		return delegate.getElementById(id);
+		return (E)delegate.getElementById(id);
 	}
 
 	
@@ -92,9 +96,10 @@ class HtmlFormWrapper {
 		return (HtmlPage) result.getNewPage();
 	}
 
+	@SuppressWarnings("unchecked")
 	public <I extends HtmlInput> I getInputByName(String name) {
 		try {
-			return delegate.getInputByName(name);
+			return (I)delegate.getInputByName(name);
 		} catch (Exception e) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Input with name " + name + " not found.");

--- a/src/main/java/br/com/caelum/seleniumdsl/htmlunit/HtmlFormWrapper.java
+++ b/src/main/java/br/com/caelum/seleniumdsl/htmlunit/HtmlFormWrapper.java
@@ -22,15 +22,13 @@ class HtmlFormWrapper {
 		this.delegate = delegate;
 	}
 
-	@SuppressWarnings("unchecked")
 	public <X> X getFirstByXPath(String xpathExpr) {
-		return (X)delegate.getFirstByXPath(xpathExpr);
+		return delegate.<X>getFirstByXPath(xpathExpr);
 	}
 
-	@SuppressWarnings("unchecked")
 	public <I extends HtmlInput> I getInputByNameOrId(String name) {
 		try {
-			return (I)getInputByNameOrIdOrDie(name);
+			return this.<I>getInputByNameOrIdOrDie(name);
 		} catch (Exception e) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Input with name or id " + name + " not found");
@@ -56,18 +54,16 @@ class HtmlFormWrapper {
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	public <I extends HtmlInput> I getInputByNameOrIdOrDie(String name) throws ElementNotFoundException {
 		try {
-			return (I)delegate.getInputByName(name);
+			return delegate.<I>getInputByName(name);
 		} catch (ElementNotFoundException e) {
-			return (I)delegate.getElementById(name);
+			return delegate.<I>getElementById(name);
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	public <E extends HtmlElement> E getElementByIdOrDie(String id) throws ElementNotFoundException {
-		return (E)delegate.getElementById(id);
+		return delegate.<E>getElementById(id);
 	}
 
 	
@@ -96,10 +92,9 @@ class HtmlFormWrapper {
 		return (HtmlPage) result.getNewPage();
 	}
 
-	@SuppressWarnings("unchecked")
 	public <I extends HtmlInput> I getInputByName(String name) {
 		try {
-			return (I)delegate.getInputByName(name);
+			return delegate.<I>getInputByName(name);
 		} catch (Exception e) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Input with name " + name + " not found.");


### PR DESCRIPTION
Modification to prevent the follow error:
"type parameters of <X>X cannot be determined; no unique maximal instance exists for type variable X with upper bounds int,java.lang.Object"

This happens when some method is generic and it calls another method that has a generic return type. I added an explicity cast in my HtmlFormWrapper class.

Curiously, this code still compiles in eclipse, but not with javac. Although using the same java/bin installation.
